### PR TITLE
feat(cmd/cup): apply command and various fixes

### DIFF
--- a/cmd/cup/config.go
+++ b/cmd/cup/config.go
@@ -58,6 +58,7 @@ func configCommand() *cli.Command {
 
 type config struct {
 	CurrentContext string              `json:"current_context"`
+	Output         string              `json:"-"`
 	Contexts       map[string]*context `json:"contexts"`
 }
 
@@ -109,6 +110,8 @@ func parseConfig(ctx *cli.Context) (config, error) {
 	if err := json.NewDecoder(fi).Decode(&conf); err != nil {
 		return config{}, err
 	}
+
+	conf.Output = ctx.String("output")
 
 	return conf, nil
 }

--- a/cmd/cup/main.go
+++ b/cmd/cup/main.go
@@ -26,6 +26,11 @@ func main() {
 				Aliases: []string{"c"},
 				Value:   path.Join(dir, "config.json"),
 			},
+			&cli.StringFlag{
+				Name:    "output",
+				Aliases: []string{"o"},
+				Value:   "table",
+			},
 		},
 		Commands: []*cli.Command{
 			{
@@ -69,17 +74,44 @@ func main() {
 						},
 					},
 					{
-						Name:     "list",
-						Aliases:  []string{"l"},
+						Name:     "get",
+						Aliases:  []string{"g"},
 						Category: "resource",
-						Usage:    "List the available resources of a given definition for the target source",
+						Usage:    "Get one or more resources",
 						Action: func(ctx *cli.Context) error {
 							cfg, err := parseConfig(ctx)
 							if err != nil {
 								return err
 							}
 
-							return list(cfg, http.DefaultClient, ctx.Args().First())
+							return get(cfg,
+								http.DefaultClient,
+								ctx.Args().First(),
+								ctx.Args().Tail()...)
+						},
+					},
+					{
+						Name:     "apply",
+						Category: "resource",
+						Usage:    "Put a resource from file on stdin",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:        "f",
+								Value:       "-",
+								Usage:       "Path to source to apply to target cupd",
+								DefaultText: "(- STDIN)",
+							},
+						},
+						Action: func(ctx *cli.Context) error {
+							cfg, err := parseConfig(ctx)
+							if err != nil {
+								return err
+							}
+
+							return apply(cfg,
+								http.DefaultClient,
+								ctx.String("f"),
+							)
 						},
 					},
 				},

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,15 @@ go 1.20
 
 require (
 	code.gitea.io/sdk/gitea v0.15.1
+	github.com/go-chi/chi v1.5.4
 	github.com/go-chi/chi/v5 v5.0.10
 	github.com/go-git/go-billy/v5 v5.4.1
 	github.com/go-git/go-git/v5 v5.8.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
+	github.com/tetratelabs/wazero v1.3.1
+	github.com/urfave/cli/v2 v2.25.7
+	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090
 )
 
 require (
@@ -20,7 +23,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
-	github.com/go-chi/chi v1.5.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/hashicorp/go-version v1.2.1 // indirect
@@ -32,8 +34,6 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/skeema/knownhosts v1.1.1 // indirect
-	github.com/tetratelabs/wazero v1.3.1 // indirect
-	github.com/urfave/cli/v2 v2.25.7 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/crypto v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/crypto v0.10.0 h1:LKqV2xt9+kDzSTfOhx4FrkEBcMrAgHSYgzywV9zcGmM=
 golang.org/x/crypto v0.10.0/go.mod h1:o4eNf7Ede1fv+hwOwZsTHl9EsPFO6q6ZvYR8vYfY45I=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
-golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
+golang.org/x/exp v0.0.0-20230725093048-515e97ebf090 h1:Di6/M8l0O2lCLc6VVRWhgCiApHV8MnQurBnFSHsQtNY=
+golang.org/x/exp v0.0.0-20230725093048-515e97ebf090/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,9 +67,29 @@ const (
 	SCMTypeGitHub = SCMType("github")
 )
 
+type URL struct {
+	*url.URL
+}
+
+func (u *URL) UnmarshalJSON(v []byte) error {
+	if u.URL == nil {
+		u.URL = &url.URL{}
+	}
+
+	if len(v) < 2 {
+		return nil
+	}
+
+	return u.URL.UnmarshalBinary(v[1 : len(v)-1])
+}
+
+func (u *URL) MarshalJSON() ([]byte, error) {
+	return u.URL.MarshalBinary()
+}
+
 type GitSource struct {
-	URL *url.URL `json:"url"`
-	SCM SCMType  `json:"scm"`
+	URL *URL    `json:"url"`
+	SCM SCMType `json:"scm"`
 }
 
 func (s *GitSource) Credentials() (user, pass string) {
@@ -82,7 +102,7 @@ func (s *GitSource) Host() string {
 }
 
 func (s *GitSource) OwnerRepo() (owner, repo string, err error) {
-	parts := strings.SplitN(s.URL.Path, "/", 2)
+	parts := strings.SplitN(s.URL.Path, "/", 3)
 	if len(parts) < 3 {
 		return "", "", fmt.Errorf("unexpected path: %q", s.URL.Path)
 	}
@@ -137,4 +157,5 @@ type TemplateController struct {
 }
 
 type WASMController struct {
+	Executable string `json:"executable"`
 }

--- a/pkg/controllers/template/template.go
+++ b/pkg/controllers/template/template.go
@@ -45,7 +45,7 @@ type Controller struct {
 // By default it uses a JSON encoding which can be overriden via WithResourceEncoding.
 func New(opts ...containers.Option[Controller]) *Controller {
 	controller := &Controller{
-		encoding: encoding.NewJSONEncoding[core.Resource](),
+		encoding: &encoding.JSONEncoding[core.Resource]{},
 		nsTmpl: template.Must(template.New("ns").
 			Funcs(funcs).
 			Parse(defaultNamespaceTmpl),

--- a/pkg/encoding/json.go
+++ b/pkg/encoding/json.go
@@ -5,23 +5,40 @@ import (
 	"io"
 )
 
-var _ AnyEncodingBuilder = (*JSON)(nil)
-
-type JSON struct {
+type JSON[T any] struct {
 	*json.Encoder
 	*json.Decoder
 }
 
-func NewJSONEncoding[T any]() EncodingBuilder[JSON, T] {
-	return EncodingBuilder[JSON, T]{}
+type JSONEncoding[T any] struct{}
+
+func (j JSONEncoding[T]) Extension() string {
+	return "json"
 }
 
-func (j JSON) Extension() string { return "json" }
-
-func (j JSON) NewEncoder(w io.Writer) AnyEncoder {
-	return &JSON{Encoder: json.NewEncoder(w)}
+func (j *JSONEncoding[T]) NewEncoder(r io.Writer) TypedEncoder[T] {
+	return NewJSONEncoder[T](r)
 }
 
-func (j JSON) NewDecoder(r io.Reader) AnyDecoder {
-	return &JSON{Decoder: json.NewDecoder(r)}
+func (j *JSONEncoding[T]) NewDecoder(w io.Reader) TypedDecoder[T] {
+	return NewJSONDecoder[T](w)
+}
+
+func NewJSONEncoder[T any](w io.Writer) *JSON[T] {
+	enc := json.NewEncoder(w)
+	return &JSON[T]{Encoder: enc}
+}
+
+func NewJSONDecoder[T any](r io.Reader) *JSON[T] {
+	dec := json.NewDecoder(r)
+	return &JSON[T]{Decoder: dec}
+}
+
+func (j JSON[T]) Encode(t *T) error {
+	return j.Encoder.Encode(t)
+}
+
+func (j JSON[T]) Decode() (*T, error) {
+	var t T
+	return &t, j.Decoder.Decode(&t)
 }

--- a/pkg/fs/local/filesystem.go
+++ b/pkg/fs/local/filesystem.go
@@ -32,5 +32,8 @@ func (f *Filesystem) View(_ context.Context, revision string, fn api.ViewFunc) e
 // Any writes performed to the target during the execution of fn will be added,
 // comitted, pushed and proposed for review on a target SCM.
 func (f *Filesystem) Update(_ context.Context, revision string, message string, fn api.UpdateFunc) (*api.Result, error) {
-	return &api.Result{}, fn(controllers.NewFSConfig(osfs.New(f.path)))
+	return &api.Result{}, fn(controllers.FSConfig{
+		FS:  osfs.New(f.path),
+		Dir: &f.path,
+	})
 }

--- a/sdk/controller/go/sdk.go
+++ b/sdk/controller/go/sdk.go
@@ -1,0 +1,97 @@
+package sdk
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"go.flipt.io/cup/pkg/encoding"
+)
+
+var ErrNotFound = errors.New("not found")
+
+type CLI struct {
+	kinds map[string]Runner
+}
+
+func NewCLI() *CLI {
+	return &CLI{kinds: map[string]Runner{}}
+}
+
+func (c *CLI) Run(ctx context.Context, args ...string) {
+	if len(args) < 3 {
+		fmt.Fprintf(os.Stderr, "too few arguments: count %d\n", len(args))
+		os.Exit(1)
+	}
+
+	kind, ok := c.kinds[os.Args[2]]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "unsupported kind: %q\n", os.Args[2])
+		os.Exit(1)
+	}
+
+	if err := kind.Run(ctx, args...); err != nil {
+		code := 1
+		if errors.Is(err, ErrNotFound) {
+			code = 2
+		}
+
+		fmt.Fprintf(os.Stderr, err.Error())
+		os.Exit(code)
+	}
+}
+
+func (c *CLI) RegisterKind(kind string, run Runner) {
+	if c.kinds == nil {
+		c.kinds = map[string]Runner{}
+	}
+
+	c.kinds[kind] = run
+}
+
+type Runner interface {
+	Run(ctx context.Context, args ...string) error
+}
+
+type Kind[T any] struct {
+	runtime KindController[T]
+}
+
+func NewKindController[T any](runtime KindController[T]) Kind[T] {
+	return Kind[T]{
+		runtime: runtime,
+	}
+}
+
+func (c Kind[T]) Run(ctx context.Context, args ...string) error {
+	enc := encoding.NewJSONEncoder[T](os.Stdout)
+	switch args[1] {
+	case "get":
+		return c.runtime.Get(ctx, args[3], args[4], enc)
+	case "list":
+		return c.runtime.List(ctx, args[3], enc)
+	case "put":
+		t, err := encoding.NewJSONDecoder[T](os.Stdin).Decode()
+		if err != nil {
+			return err
+		}
+
+		return c.runtime.Put(ctx, args[3], args[4], t)
+	case "delete":
+		if len(args) < 5 {
+			panic("delete <kind> <namespace> <name>")
+		}
+
+		return c.runtime.Delete(ctx, args[3], args[4])
+	default:
+		return fmt.Errorf("unexpected command: %q", args[1])
+	}
+}
+
+type KindController[T any] interface {
+	Get(ctx context.Context, namespace, name string, enc encoding.TypedEncoder[T]) error
+	List(ctx context.Context, namespace string, enc encoding.TypedEncoder[T]) error
+	Put(ctx context.Context, namespace, name string, t *T) error
+	Delete(ctx context.Context, namespace, name string) error
+}


### PR DESCRIPTION
This supercedes a lot of the changes in #25 

It includes:

- rename `cup ctl list` to `cup ctl get`
- implement `cup apply`
- wire up the WASM controller
- Fix some git authentication issues
- add derived put and delete commit messages
- fix git URL parsing in config
- refactor json encoding utility
- revampl the old `sdk/go` into `sdk/controller/go`