### PR TITLE
feat(cmd/cup): print PR on edit and apply

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -29,7 +29,13 @@ type UpdateFunc func(controllers.FSConfig) error
 
 // Result is the result of performing an update on a target Source.
 type Result struct {
-	ID ulid.ULID
+	ID       ulid.ULID `json:"id"`
+	Proposal *Proposal `json:"proposal"`
+}
+
+type Proposal struct {
+	Source string `json:"source"`
+	URL    string `json:"url"`
 }
 
 // Source is the abstraction around a target source filesystem.
@@ -231,6 +237,8 @@ func (s *Server) register(cntl Controller, version string, def *core.ResourceDef
 			return
 		}
 
+		w.WriteHeader(http.StatusAccepted)
+
 		if err := json.NewEncoder(w).Encode(result); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -265,6 +273,8 @@ func (s *Server) register(cntl Controller, version string, def *core.ResourceDef
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+
+		w.WriteHeader(http.StatusAccepted)
 
 		if err := json.NewEncoder(w).Encode(result); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -223,7 +223,7 @@ func Test_Server_Put(t *testing.T) {
 
 	defer resp.Body.Close()
 
-	if !assert.Equal(t, http.StatusOK, resp.StatusCode) {
+	if !assert.Equal(t, http.StatusAccepted, resp.StatusCode) {
 		data, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		t.Log(string(data))
@@ -281,7 +281,7 @@ func Test_Server_Delete(t *testing.T) {
 
 	defer resp.Body.Close()
 
-	if !assert.Equal(t, http.StatusOK, resp.StatusCode) {
+	if !assert.Equal(t, http.StatusAccepted, resp.StatusCode) {
 		data, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		t.Log(string(data))

--- a/pkg/source/git/scm/gitea/scm.go
+++ b/pkg/source/git/scm/gitea/scm.go
@@ -6,6 +6,7 @@ import (
 
 	"code.gitea.io/sdk/gitea"
 	"github.com/oklog/ulid/v2"
+	"go.flipt.io/cup/pkg/api"
 	"go.flipt.io/cup/pkg/source/git"
 )
 
@@ -58,16 +59,19 @@ func (s *SCM) Merge(_ context.Context, id ulid.ULID) error {
 	return nil
 }
 
-func (s *SCM) Propose(_ context.Context, p git.Proposal) (git.ProposalResponse, error) {
-	_, _, err := s.client.CreatePullRequest(s.owner, s.repository, gitea.CreatePullRequestOption{
+func (s *SCM) Propose(_ context.Context, p git.Proposal) (*api.Proposal, error) {
+	pr, _, err := s.client.CreatePullRequest(s.owner, s.repository, gitea.CreatePullRequestOption{
 		Head:  p.Head,
 		Base:  p.Base,
 		Title: p.Title,
 		Body:  p.Body,
 	})
 	if err != nil {
-		return git.ProposalResponse{}, err
+		return nil, err
 	}
 
-	return git.ProposalResponse{}, nil
+	return &api.Proposal{
+		Source: "gitea",
+		URL:    pr.HTMLURL,
+	}, nil
 }

--- a/pkg/source/git/scm/github/scm.go
+++ b/pkg/source/git/scm/github/scm.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/go-github/v53/github"
 	"github.com/oklog/ulid/v2"
+	"go.flipt.io/cup/pkg/api"
 	"go.flipt.io/cup/pkg/source/git"
 )
 
@@ -51,16 +52,19 @@ func (s *SCM) Merge(ctx context.Context, id ulid.ULID) error {
 	return nil
 }
 
-func (s *SCM) Propose(ctx context.Context, p git.Proposal) (git.ProposalResponse, error) {
-	_, _, err := s.client.PullRequests.Create(ctx, s.owner, s.repository, &github.NewPullRequest{
+func (s *SCM) Propose(ctx context.Context, p git.Proposal) (*api.Proposal, error) {
+	pr, _, err := s.client.PullRequests.Create(ctx, s.owner, s.repository, &github.NewPullRequest{
 		Head:  github.String(p.Head),
 		Base:  github.String(p.Base),
 		Title: github.String(p.Title),
 		Body:  github.String(p.Body),
 	})
 	if err != nil {
-		return git.ProposalResponse{}, err
+		return nil, err
 	}
 
-	return git.ProposalResponse{}, nil
+	return &api.Proposal{
+		Source: "github",
+		URL:    pr.GetHTMLURL(),
+	}, nil
 }

--- a/pkg/source/git/scm/mem/scm.go
+++ b/pkg/source/git/scm/mem/scm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/oklog/ulid/v2"
+	"go.flipt.io/cup/pkg/api"
 	"go.flipt.io/cup/pkg/source/git"
 )
 
@@ -20,8 +21,8 @@ func New() *SCM {
 }
 
 // Propose stores the provided proposal in a map and returns a nil error and empty response.
-func (s *SCM) Propose(_ context.Context, p git.Proposal) (git.ProposalResponse, error) {
+func (s *SCM) Propose(_ context.Context, p git.Proposal) (*api.Result, error) {
 	s.proposals[p.ID] = p
 
-	return git.ProposalResponse{}, nil
+	return &api.Result{ID: p.ID}, nil
 }

--- a/pkg/source/git/source.go
+++ b/pkg/source/git/source.go
@@ -36,13 +36,9 @@ type Proposal struct {
 	Body  string
 }
 
-// ProposalResponse is a structure which will contain any details identifying
-// the successful proposition.
-type ProposalResponse struct{}
-
 // SCM is an abstraction around repositories and source control providers.
 type SCM interface {
-	Propose(context.Context, Proposal) (ProposalResponse, error)
+	Propose(context.Context, Proposal) (*api.Proposal, error)
 }
 
 // Source is an implementation of api.Source
@@ -221,13 +217,15 @@ func (s *Source) Update(ctx context.Context, rev, message string, fn api.UpdateF
 		return nil, fmt.Errorf("pushing changes: %w", err)
 	}
 
-	if _, err := s.scm.Propose(ctx, Proposal{
+	result.Proposal, err = s.scm.Propose(ctx, Proposal{
 		Head:  branch,
 		Base:  rev,
 		Title: message,
 		Body:  message,
-	}); err != nil {
+	})
+	if err != nil {
 		return nil, fmt.Errorf("proposing change: %w", err)
+
 	}
 
 	return result, nil


### PR DESCRIPTION
This adds output on `apply` and `edit` containing the PR created.

```console
➜  cup edit flags useClosedAI
ID                           SOURCE   URL
01H7DFG3VZEWPFPKQ8EXVMZ2ZA   github   https://github.com/predictab-le/config/pull/17
```