### PR TITLE
fix: dont push and propose on empty commit

### DIFF
--- a/cmd/cup/main.go
+++ b/cmd/cup/main.go
@@ -42,6 +42,11 @@ func main() {
 				Name:    "namespace",
 				Aliases: []string{"n"},
 			},
+			&cli.StringFlag{
+				Name:    "level",
+				Aliases: []string{"l"},
+				Usage:   "set the logging level (default: \"info\")",
+			},
 		},
 		Commands: []*cli.Command{
 			{

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -251,6 +251,12 @@ func (s *Server) register(cntl Controller, version string, def *core.ResourceDef
 			return
 		}
 
+		// result was empty and so no proposal or change was made
+		if result.Empty {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
 		w.WriteHeader(http.StatusAccepted)
 
 		if err := json.NewEncoder(w).Encode(result); err != nil {
@@ -288,8 +294,7 @@ func (s *Server) register(cntl Controller, version string, def *core.ResourceDef
 			return
 		}
 
-		// result was empty and so no proposal or change
-		// was made
+		// result was empty and so no proposal or change was made
 		if result.Empty {
 			w.WriteHeader(http.StatusNoContent)
 			return


### PR DESCRIPTION
Fixes #49 

I am seeing weird behaviour from go-git, where it should be producing an error no change (because AllowEmptyCommits is `false`) and yet it is still producing empty commits. So, I have had to work around this for now with a call to status. This could be expensive, so I would like to investigate further. However, for now, this fixes the experience.

```
➜  cup -l debug edit flags chat-enabled
time=2023-08-15T11:43:05.027+01:00 level=DEBUG msg="No change was generated by proposal"
```

**Additionally**
- Added `-level` for log level
- Added timestamps to signatures on commits