### PR TITLE
feat(controllers/template): indent JSON output

### DIFF
--- a/build/build/base.go
+++ b/build/build/base.go
@@ -64,7 +64,11 @@ func Base(ctx context.Context, client *dagger.Client, opts ...Option) (*dagger.C
 		WithEnvVariable("GOCACHE", goBuildCachePath).
 		WithEnvVariable("GOMODCACHE", goModCachePath).
 		WithExec([]string{"apk", "add", "gcc", "build-base"}).
-		WithDirectory("/src", client.Host().Directory("."), dagger.ContainerWithDirectoryOpts{
+		WithDirectory("/src", client.Host().Directory(".", dagger.HostDirectoryOpts{
+			Exclude: []string{
+				"./docs/",
+			},
+		}), dagger.ContainerWithDirectoryOpts{
 			Include: []string{
 				"./build/",
 				"./cmd/",

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -242,11 +242,7 @@ func Test_Server_Put(t *testing.T) {
 	data, err := io.ReadAll(fi)
 	require.NoError(t, err)
 
-	expected := &bytes.Buffer{}
-	require.NoError(t, json.Compact(expected, []byte(bazPayload)))
-	expected.Write([]byte{'\n'})
-
-	assert.Equal(t, expected.Bytes(), data)
+	assert.Equal(t, bazPayload, string(data))
 }
 
 func Test_Server_Delete(t *testing.T) {
@@ -297,15 +293,16 @@ func Test_Server_Delete(t *testing.T) {
 }
 
 const bazPayload = `{
-    "apiVersion": "test.cup.flipt.io/v1alpha1",
-    "kind": "Resource",
-    "metadata": {
-        "namespace": "default",
-        "name": "baz",
-        "labels": {
-            "foo": "bar"
-        },
-        "annotations": {}
+  "apiVersion": "test.cup.flipt.io/v1alpha1",
+  "kind": "Resource",
+  "metadata": {
+    "namespace": "default",
+    "name": "baz",
+    "labels": {
+      "foo": "bar"
     },
-    "spec": {}
-}`
+    "annotations": {}
+  },
+  "spec": {}
+}
+`

--- a/pkg/controllers/template/template.go
+++ b/pkg/controllers/template/template.go
@@ -46,7 +46,10 @@ type Controller struct {
 // By default it uses a JSON encoding which can be overriden via WithResourceEncoding.
 func New(opts ...containers.Option[Controller]) *Controller {
 	controller := &Controller{
-		encoding: &encoding.JSONEncoding[core.Resource]{},
+		encoding: &encoding.JSONEncoding[core.Resource]{
+			Prefix: "",
+			Indent: "  ",
+		},
 		nsTmpl: template.Must(template.New("ns").
 			Funcs(funcs).
 			Parse(defaultNamespaceTmpl),

--- a/pkg/encoding/json.go
+++ b/pkg/encoding/json.go
@@ -10,14 +10,19 @@ type JSON[T any] struct {
 	*json.Decoder
 }
 
-type JSONEncoding[T any] struct{}
+type JSONEncoding[T any] struct {
+	Prefix string
+	Indent string
+}
 
 func (j JSONEncoding[T]) Extension() string {
 	return "json"
 }
 
 func (j *JSONEncoding[T]) NewEncoder(r io.Writer) TypedEncoder[T] {
-	return NewJSONEncoder[T](r)
+	enc := NewJSONEncoder[T](r)
+	enc.SetIndent(j.Prefix, j.Indent)
+	return enc
 }
 
 func (j *JSONEncoding[T]) NewDecoder(w io.Reader) TypedDecoder[T] {


### PR DESCRIPTION
Eventually we could make this configurable.
For now, this just hard-codes the JSON encoding output to have two space indentation.