### PR TITLE
fix(controllers/template): ensure list glob facets by gvk and ns

### DIFF
--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -84,7 +84,10 @@ func New(ctx context.Context, cfg *config.Config) (*api.Configuration, error) {
 			if err := core.DecodeController(
 				buf,
 				func(tc core.TemplateController) error {
-					c.Controllers[tc.Metadata.Name] = template.New()
+					c.Controllers[tc.Metadata.Name] = template.New(
+						template.WithListTemplate(tc.Spec.Spec.ListTemplate),
+						template.WithResourceTemplate(tc.Spec.Spec.ResourceTemplate),
+					)
 					return nil
 				},
 				func(w core.WASMController) error {

--- a/pkg/api/core/controller.go
+++ b/pkg/api/core/controller.go
@@ -74,8 +74,8 @@ type ControllerSpec[T any] struct {
 }
 
 type TemplateControllerSpec struct {
-	DirectoryTemplate string `json:"directory_template"`
-	PathTemplate      string `json:"path_template"`
+	ListTemplate     string `json:"list_template"`
+	ResourceTemplate string `json:"resource_template"`
 }
 
 type WASMControllerSpec struct {

--- a/pkg/controllers/template/template.go
+++ b/pkg/controllers/template/template.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	defaultNamespaceTmpl = `{{ .Namespace }}/*.json`
+	defaultNamespaceTmpl = `{{ .Namespace }}/{{ .Group }}-{{ .Version }}-{{ .Kind }}-*.json`
 	defaultResourceTmpl  = `{{ .Namespace }}/{{ .Group }}-{{ .Version }}-{{ .Kind }}-{{ .Name }}.json`
 )
 


### PR DESCRIPTION
This was causing any json file to be respected and returning by the template controller.
This adds the same restrictions on the filename to ensure it contains the group, version and kind expected.

It also makes the templates configurable. Something I just never got around to wiring up before.