### PR TITLE
feat: Add `Transformer` type

### DIFF
--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -22,9 +22,10 @@ import (
 
 func New(ctx context.Context, cfg *config.Config) (*api.Configuration, error) {
 	c := &api.Configuration{
-		Definitions: containers.MapStore[string, *core.ResourceDefinition]{},
-		Controllers: containers.MapStore[string, api.Controller]{},
-		Bindings:    containers.MapStore[string, *core.Binding]{},
+		Definitions:  containers.MapStore[string, *core.ResourceDefinition]{},
+		Controllers:  containers.MapStore[string, api.Controller]{},
+		Bindings:     containers.MapStore[string, *core.Binding]{},
+		Transformers: containers.MapStore[string, *core.Transformer]{},
 	}
 
 	dir := os.DirFS(cfg.API.Resources)
@@ -109,6 +110,14 @@ func New(ctx context.Context, cfg *config.Config) (*api.Configuration, error) {
 			}
 
 			c.Bindings[binding.Metadata.Name] = &binding
+		case core.TransformerKind:
+			var transformer core.Transformer
+
+			if err := json.NewDecoder(buf).Decode(&transformer); err != nil {
+				return fmt.Errorf("parsing transformer: %w", err)
+			}
+
+			c.Transformers[transformer.Spec.Kind] = &transformer
 		}
 
 		return nil

--- a/pkg/api/core/resource.go
+++ b/pkg/api/core/resource.go
@@ -7,6 +7,7 @@ import (
 const (
 	ResourceDefinitionKind = "ResourceDefinition"
 	BindingKind            = "Binding"
+	TransformerKind        = "Transformer"
 )
 
 // Resource is the core API resource definition used to communicate
@@ -38,4 +39,12 @@ type Binding Object[BindingSpec]
 type BindingSpec struct {
 	Resources  []string
 	Controller string
+}
+
+type Transformer Object[TransformerSpec]
+
+type TransformerSpec struct {
+	Kind       string
+	Controller string
+	Template   string // template to transform a ResourceDefinition into
 }


### PR DESCRIPTION
# Transformers

The motivation for adding a `Transformer` type is to template out a definition of a JSON payload that can be materialized into an actual one based on the `ResourceDefintion`.

The main use case here that I thought of is abstracting away complex details of a definition. For instance, a Kubernetes Deployment type probably has more details that a developer like myself does not care about, and would rather not have to touch those parts of a definition.

Transformers will allow operators of `cup` to create standards/conventions of a rather complex type, so consumers of the API can focus on the parts that matter.

## Storage

Right now the entire payload that is stored is the transformed payload that is nested under the key "transformed", and the actual Resource definition with the values that is nested under the key "definition".

The `ResourceDefinition` will also be given the label "transformed", which will have a value of "yes", so consumers of the API can know if this was a transformed Resource from the service perspective.